### PR TITLE
Dockerfile.rhel: Use the newest PNC Presto 322 build.

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,7 +1,7 @@
 FROM rhel7:7-released AS build
 
-ENV PRESTO_VERSION 315.0
-ENV RH_PRESTO_PATCH_VERSION 00003
+ENV PRESTO_VERSION 322.0
+ENV RH_PRESTO_PATCH_VERSION 00001
 ENV RH_PRESTO_VERSION ${PRESTO_VERSION}.0.redhat-${RH_PRESTO_PATCH_VERSION}
 ENV RH_PRESTO_BREW_DIR ${PRESTO_VERSION}.0.redhat_${RH_PRESTO_PATCH_VERSION}
 ENV PRESTO_SERVER_OUT /build/presto-server/target/presto-server-${PRESTO_VERSION}
@@ -45,7 +45,7 @@ RUN set -x; \
 
 RUN mkdir -p /opt/presto
 
-ENV PRESTO_VERSION 315.0
+ENV PRESTO_VERSION 322.0
 ENV PRESTO_HOME /opt/presto/presto-server
 ENV PRESTO_CLI /opt/presto/presto-cli
 # Note: podman was having difficulties evaluating the PRESTO_VERSION


### PR DESCRIPTION
We've been using 322 for our origin testing for a while now, so this should be a safe bump in versioning. This 322 build would also contain the presto-prometheus connector, which was previously missing in the ART builds.

Unfortunately, this is a bit of a guessing game as to whether or not this works as CI builds the Dockerfile.okd instead of the Dockerfile.rhel. I built this locally, mounting the unsigned yum repos as a volume using podman and deploy Metering manually, overriding the presto image to point to this custom rhel image and it seems like everything is working as intended. We'll get an email from ART if something fails so it's not the end of the world and we'll make the requisite changes.