### PR TITLE
.dockerignore: Explicitly ignore the path to the animal-sniffer-annotations jar.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
 # ignore anything inside a target directory, as that is the output of a maven
 # build and we want a fresh environment
 **/target/*
+# (tflannag): Was having difficulties when building the 322
+# master build using imagebuilder as it was improperly
+# processing the presto-server tar file that contains symlinks
+# target/**/*
+# TODO: find a better solution than this
+target/presto-server-322.0/lib/animal-sniffer-annotations-1.14.jar


### PR DESCRIPTION
When building the Dockerfile.rhel locally using imagebuilder, I keep getting the following error:

```bash
ata=false ok=false skip=false err=<nil>
I0507 17:48:19.860635  128325 archive.go:43] Transform target/presto-server-322.0/plugin/tpch/jackson-databind-2.10.0.jar -> /opt/presto/presto-server/plugin/tpch/jackson-databind-2.10.0.jar: data=false ok=false skip=false err=<nil>
I0507 17:48:19.860662  128325 archive.go:43] Transform target/presto-server-322.0/plugin/tpch/jackson-datatype-jdk8-2.10.0.jar -> /opt/presto/presto-server/plugin/tpch/jackson-datatype-jdk8-2.10.0.jar: data=false ok=false skip=false err=<nil>
I0507 17:48:19.860696  128325 archive.go:43] Transform target/presto-server-322.0/plugin/tpch/jsr305-3.0.2.jar -> /opt/presto/presto-server/plugin/tpch/jsr305-3.0.2.jar: data=false ok=false skip=false err=<nil>
I0507 17:48:19.860722  128325 archive.go:43] Transform target/presto-server-322.0/plugin/tpch/presto-tpch-322.0.0.redhat-00002.jar -> /opt/presto/presto-server/plugin/tpch/presto-tpch-322.0.0.redhat-00002.jar: data=false ok=false skip=false err=<nil>
I0507 17:48:19.860819  128325 archive.go:43] Transform target/presto-server-322.0/plugin/tpch/tpch-0.10.jar -> /opt/presto/presto-server/plugin/tpch/tpch-0.10.jar: data=false ok=false skip=false err=<nil>
API error (500): Error processing tar file(exit status 1): link /target/presto-server-322.0/lib/animal-sniffer-annotations-1.14.jar /opt/presto/presto-server/plugin/accumulo/animal-sniffer-annotations-1.14.jar: no such file or directory
```

While this file does exist in the build stage, imagebuilder appears to be improperly processing symlinks in a tar file, so this is just a workaround for now.