### PR TITLE
Dockerfile: Add the summary label.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,7 +148,7 @@ WORKDIR $PRESTO_HOME
 CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Presto." \
-      summary="This is an image used by operator-metering to to install and run Presto." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Presto." \
+      summary="This is an image used by the Metering Operator to install and run Presto." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,5 +149,6 @@ CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
       io.k8s.description="This is an image used by operator-metering to to install and run Presto." \
+      summary="This is an image used by operator-metering to to install and run Presto." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -148,5 +148,6 @@ CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
       io.k8s.description="This is an image used by operator-metering to to install and run Presto." \
+      summary="This is an image used by operator-metering to to install and run Presto." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -147,7 +147,7 @@ WORKDIR $PRESTO_HOME
 CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Presto." \
-      summary="This is an image used by operator-metering to to install and run Presto." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Presto." \
+      summary="This is an image used by the Metering Operator to install and run Presto." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -56,5 +56,6 @@ CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
       io.k8s.description="This is an image used by operator-metering to to install and run Presto." \
+      summary="This is an image used by operator-metering to to install and run Presto." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -55,7 +55,7 @@ WORKDIR $PRESTO_HOME
 CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
-      io.k8s.description="This is an image used by operator-metering to to install and run Presto." \
-      summary="This is an image used by operator-metering to to install and run Presto." \
+      io.k8s.description="This is an image used by the Metering Operator to install and run Presto." \
+      summary="This is an image used by the Metering Operator to install and run Presto." \
       io.openshift.tags="openshift" \
       maintainer="<metering-team@redhat.com>"


### PR DESCRIPTION
This is necessary to pass the inherit_labels CVP check that the Presto images were previously failing.