### PR TITLE
Dockerfile: Install the Python3 rpm.

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -10,7 +10,7 @@ RUN chmod u+x /tmp/opt_maven_install.sh && /tmp/opt_maven_install.sh $OPENSHIFT_
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
 
 RUN set -x; \
-    INSTALL_PKGS="openssl java-1.8.0-openjdk java-1.8.0-openjdk-devel less rsync tini faq" \
+    INSTALL_PKGS="openssl java-1.8.0-openjdk java-1.8.0-openjdk-devel less rsync tini faq python3" \
     && yum install --setopt=skip_missing_names_on_install=False -y $INSTALL_PKGS \
     && yum clean all \
     && rm -rf /var/cache/yum


### PR DESCRIPTION
With the migration towards using rhel8 base images, we were seeing the following error message pop up:
```
Adding /var/run/configmaps/service-ca-bundle/service-ca.crt to /etc/alternatives/jre/lib/security/cacerts
Certificate was added to keystore
env: 'python': No such file or directory
```

This was because the Presto launcher script is written in Python, and by default, rhel8 does not install any Python version to path which means we need to explicitly install a specific python version in order to get a python binary in the container's path.