### PR TITLE
Bug 1872080: Alias the python command to the python3 binary.

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -15,6 +15,13 @@ RUN set -x; \
     && yum clean all \
     && rm -rf /var/cache/yum
 
+# Workaround to RHEL8 not having python by default The current version (328) of the
+# Presto fork uses a python script for it's launcher program, which is supposedly
+# python2 and python3 compatible.
+RUN alias python=python3
+# TODO: debug artifact - remove once passing images
+RUN python --version
+
 RUN mkdir -p /opt/presto
 
 ENV PRESTO_VERSION 328.0

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -18,8 +18,7 @@ RUN set -x; \
 # Workaround to RHEL8 not having python by default The current version (328) of the
 # Presto fork uses a python script for it's launcher program, which is supposedly
 # python2 and python3 compatible.
-RUN alias python=python3
-# TODO: debug artifact - remove once passing images
+RUN alternatives --set python /usr/bin/python3
 RUN python --version
 
 RUN mkdir -p /opt/presto


### PR DESCRIPTION
As we continue migrating towards using RHEL8 base images, we're seeing problems arrive when calling the bin/launcher script, which is a wrapper script around the bin/launcher.py python script. By default, RHEL8 does not ship a python version, and instead makes you decide between what python major version you want to install and use. When installing the python3 rpm, the bin/launcher.py python script is still failing as it's referencing the `#! /usr/bin/env python` shebang, which isn't in the PATH.

I think we have a couple of options here:
1. Alias the python command to the python3 binary
2. Only install the python2 rpm (e.g. `yum install python2`)
3. Symbolically link the python3 binary to /usr/bin/python

Update:
- After re-reading the [What, no Python in Red Hat Enterprise Linux 8?](https://developers.redhat.com/blog/2019/05/07/what-no-python-in-red-hat-enterprise-linux-8/) developer article, it looks like there's an "alternatives" command that can be used to set the python binary to a specific python version. They don't recommend relying on this infrastructure on the application-level, but this is sufficient for our use-case as the bin/launcher.py is supposedly python2 and python3 compatible.