### PR TITLE
Bug 1872080: Move the jmx prometheus jar into the correct build location. 

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -7,6 +7,9 @@ RUN mkdir -p /build /build/presto-server/target /build/presto-cli/target
 COPY opt_maven_install.sh /tmp/
 RUN chmod u+x /tmp/opt_maven_install.sh && /tmp/opt_maven_install.sh $OPENSHIFT_CI
 
+# Debug check for jmx_prometheus_javaagent missing from the /build/ path
+RUN ls /build/jmx_prometheus_javaagent.jar
+
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
 
 RUN set -x; \

--- a/opt_maven_install.sh
+++ b/opt_maven_install.sh
@@ -21,7 +21,7 @@ if [[ "$1" == "true" ]]; then
     # build presto
     cd /build && mvn --batch-mode --errors -Dmaven.javadoc.skip=true -Dmaven.source.skip=true -DskipTests -DfailIfNoTests=false -Dtest=false -DdownloadSources -DdownloadJavadoc clean package -pl '!presto-testing-docker' -Dmaven.repo.local=.m2/repository
     # Install prometheus-jmx agent
-    mvn --batch-mode dependency:get -Dartifact=io.prometheus.jmx:jmx_prometheus_javaagent:0.3.1:jar -Ddest=/build/jmx_prometheus_javaagent.jar
+    mvn --batch-mode dependency:get -Dartifact=io.prometheus.jmx:jmx_prometheus_javaagent:0.3.1:jar -Ddest=/build/jmx_prometheus_javaagent.jar && mv $HOME/.m2/repository/io/prometheus/jmx/jmx_prometheus_javaagent/0.3.1/jmx_prometheus_javaagent-0.3.1.jar /build/jmx_prometheus_javaagent.jar
 
     # The preceeding commands build a presto 328. The last stage of Dockerfile.rhel expects this content at 328.0.
     # This hardlinking allows the CI build and ART production build Dockerfile to be the same.


### PR DESCRIPTION
Continuing to iron out problems with the migration to using RHEL8 images. After seeing problems with the python binary missing in PATH, we're now in familiar territory where the jmx_prometheus_javaagent:0.3.1 jar file is missing when we attempt to load that, which is something we also saw in the Hadoop image. IT looks like there may be something wrong with our maven environment, but my understanding is that maven isn't respecting the `-Ddest` flag value, and instead is storing that downloaded jar into the default ~/.m2/repository location. If we move that jar from that directory to the expected path that the Dockerfile is configured to use, this error should discontinue.

This also adds a debug check that verifies if the jar is placed in the location we expect it to be in.