### PR TITLE
Dockerfile: Avoid using the `alternatives` command when building outside of CI

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -21,8 +21,10 @@ RUN set -x; \
 # Workaround to RHEL8 not having python by default The current version (328) of the
 # Presto fork uses a python script for it's launcher program, which is supposedly
 # python2 and python3 compatible.
-RUN alternatives --set python /usr/bin/python3
-RUN python --version
+# 
+# TODO(tflannag): we should move this outside of the conditional build script
+# once ART has moved to RHEL8 images. 
+RUN export OPENSHIFT_CI=${OPENSHIFT_CI:=false}; if [ "$OPENSHIFT_CI" == "true" ]; then alternatives --set python /usr/bin/python3; fi
 
 RUN mkdir -p /opt/presto
 
@@ -64,7 +66,7 @@ WORKDIR $PRESTO_HOME
 CMD ["tini", "--", "bin/launcher", "run"]
 
 LABEL io.k8s.display-name="OpenShift Presto" \
-      io.k8s.description="This is an image used by the Metering Operator to install and run Presto." \
-      summary="This is an image used by the Metering Operator to install and run Presto." \
-      io.openshift.tags="openshift" \
-      maintainer="<metering-team@redhat.com>"
+    io.k8s.description="This is an image used by the Metering Operator to install and run Presto." \
+    summary="This is an image used by the Metering Operator to install and run Presto." \
+    io.openshift.tags="openshift" \
+    maintainer="<metering-team@redhat.com>"

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -25,6 +25,7 @@ RUN set -x; \
 # TODO(tflannag): we should move this outside of the conditional build script
 # once ART has moved to RHEL8 images. 
 RUN export OPENSHIFT_CI=${OPENSHIFT_CI:=false}; if [ "$OPENSHIFT_CI" == "true" ]; then alternatives --set python /usr/bin/python3; fi
+RUN python --version
 
 RUN mkdir -p /opt/presto
 


### PR DESCRIPTION
Currently, the Dockerfile.rhel is configured to use RHEL8-based images whereas ART hasn't made the migration over from RHEL7 to RHEL8 yet. In order to abstract the linkage of the python3 rpm to the default python path, we use the `alternatives` command, which seems to be non-existent in the default RHEL7 image that ART is configured to use. As a result, CI is able to successfully build presto RHEL images, whereas ART is failing to build as `alteratives` is an undefined command.